### PR TITLE
feat: Add GitHub Actions workflow for Android builds

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -1,0 +1,40 @@
+name: Android Build CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v2
+
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug
+
+    - name: Upload debug APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: debug-app
+        path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automate the Android build process.

The workflow is triggered on push and pull_request events to the main branch. It performs the following steps:
- Checks out the repository code.
- Sets up JDK 17.
- Sets up the Android SDK.
- Makes the gradlew script executable.
- Builds the debug version of the app using `./gradlew assembleDebug`.
- Uploads the generated debug APK (`app-debug.apk`) as a workflow artifact named `debug-app`.

This will allow for easier access to debug builds and ensure the app builds correctly on a clean environment.