### PR TITLE
feat: Implement code folding and performance improvements

### DIFF
--- a/editor/src/main/java/com/itsvks/code/CodeEditorState.kt
+++ b/editor/src/main/java/com/itsvks/code/CodeEditorState.kt
@@ -7,13 +7,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import com.itsvks.code.core.emptyStringBuilder
-import com.itsvks.code.core.getLine
-import com.itsvks.code.core.insertLineAt
-import com.itsvks.code.core.lineCount
-import com.itsvks.code.core.removeLineAt
-import com.itsvks.code.core.toStringBuilder
-import com.itsvks.code.core.updateLine
+import com.itsvks.code.core.FoldableRange
+import com.itsvks.code.core.findBraceFoldableRanges
+// import com.itsvks.code.core.emptyStringBuilder // Not used anymore
+// import com.itsvks.code.core.getLine // Still used via CodeEditorState.getLine()
+// import com.itsvks.code.core.insertLineAt // Still used via CodeEditorState.insertLine()
+// import com.itsvks.code.core.lineCount // Still used via CodeEditorState.lineCount
+// import com.itsvks.code.core.removeLineAt // Still used via CodeEditorState.removeLine()
+// import com.itsvks.code.core.updateLine // Still used via CodeEditorState.updateLine()
 import com.itsvks.code.language.Language
 import com.itsvks.code.language.LanguageRegistry
 import com.itsvks.code.language.PlainTextLanguage
@@ -25,7 +26,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -38,7 +38,7 @@ fun rememberCodeEditorState(
 ): CodeEditorState {
     val state = remember {
         CodeEditorState(
-            initialContentSb = emptyStringBuilder(),
+            initialLines = emptyList(),
             initialLanguage = initialLanguage,
             initialTheme = initialTheme
         )
@@ -65,7 +65,7 @@ fun rememberCodeEditorState(
 ): CodeEditorState {
     val state = remember {
         CodeEditorState(
-            initialContentSb = emptyStringBuilder(),
+            initialLines = emptyList(),
             initialLanguage = initialLanguage,
             initialTheme = initialTheme
         )
@@ -91,19 +91,30 @@ fun rememberCodeEditorState(
     theme: EditorTheme = VsCodeDarkTheme
 ): CodeEditorState {
     return remember(text, language, theme) {
-        CodeEditorState(text.toStringBuilder(), language, theme)
+        CodeEditorState(text.lines(), language, theme)
     }
 }
 
 class CodeEditorState(
-    initialContentSb: StringBuilder = emptyStringBuilder(),
+    initialLines: List<String> = emptyList(),
     initialLanguage: Language = PlainTextLanguage,
     initialTheme: EditorTheme = AtomOneDarkTheme
 ) {
-    private var _internalStringBuilder: StringBuilder = initialContentSb
+    private var _lines: List<String> = initialLines
+        set(value) {
+            field = value
+            _foldableRanges.value = findBraceFoldableRanges(field)
+            // Decide on _foldedLines reconciliation strategy for direct _lines updates if any outside setText/setFile etc.
+        }
 
-    private val _content = MutableStateFlow(_internalStringBuilder)
-    val content = _content.asStateFlow()
+    private val _content = MutableStateFlow<List<String>>(initialLines)
+    val content: StateFlow<List<String>> = _content.asStateFlow()
+
+    private val _foldableRanges = MutableStateFlow<List<FoldableRange>>(emptyList())
+    val foldableRanges: StateFlow<List<FoldableRange>> = _foldableRanges.asStateFlow()
+
+    private val _foldedLines = MutableStateFlow<Set<Int>>(emptySet())
+    val foldedLines: StateFlow<Set<Int>> = _foldedLines.asStateFlow()
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
@@ -111,24 +122,36 @@ class CodeEditorState(
     var language by mutableStateOf(initialLanguage)
     var theme by mutableStateOf(initialTheme)
 
-    val lineCount get() = _internalStringBuilder.lineCount
+    val lineCount get() = _lines.size
 
-    private fun updateContent(newSb: StringBuilder) {
-        _internalStringBuilder = newSb
-        _content.update { _internalStringBuilder }
+    init {
+        // Initial calculation for foldable ranges when state is created with initialLines
+        _foldableRanges.value = findBraceFoldableRanges(_lines)
     }
 
     fun setText(text: String) {
         _isLoading.update { false }
-        updateContent(text.toStringBuilder())
+        _lines = text.lines()
+        // _foldableRanges.value is updated by _lines setter
+        _foldedLines.value = emptySet()
+        _content.update { _lines }
     }
 
     suspend fun setFile(file: File) {
         _isLoading.update { true }
-        updateContent("Loading...".toStringBuilder())
+        // Temporary state while loading
+        val loadingLines = listOf("Loading...")
+        _lines = loadingLines
+        // _foldableRanges.value is updated by _lines setter for loadingLines
+        _foldedLines.value = emptySet()
+        _content.update { _lines } // Show "Loading..."
+
         try {
-            val newContentSb = file.toStringBuilder()
-            updateContent(newContentSb)
+            val newLines = file.useLines { it.toList() }
+            _lines = newLines
+            // _foldableRanges.value is updated by _lines setter for newLines
+            _foldedLines.value = emptySet() // Reset folds for new file
+            _content.update { _lines }
         } finally {
             _isLoading.update { false }
         }
@@ -136,28 +159,75 @@ class CodeEditorState(
 
     suspend fun setInputStream(inputStream: InputStream) {
         _isLoading.update { true }
-        updateContent("Loading...".toStringBuilder())
+        // Temporary state while loading
+        val loadingLines = listOf("Loading...")
+        _lines = loadingLines
+        // _foldableRanges.value is updated by _lines setter for loadingLines
+        _foldedLines.value = emptySet()
+        _content.update { _lines } // Show "Loading..."
+
         try {
-            val newContentSb = inputStream.toStringBuilder()
-            updateContent(newContentSb)
+            val newLines = inputStream.bufferedReader(Charsets.UTF_8).useLines { it.toList() }
+            _lines = newLines
+            // _foldableRanges.value is updated by _lines setter for newLines
+            _foldedLines.value = emptySet() // Reset folds for new stream
+            _content.update { _lines }
         } finally {
             _isLoading.update { false }
         }
     }
 
+    private fun updateLinesAndFolds(newLines: List<String>) {
+        _lines = newLines
+        // _foldableRanges.value is updated by _lines setter
+        val newFoldedLines = _foldedLines.value.filter { foldedStartLine ->
+            _foldableRanges.value.any { it.startLine == foldedStartLine }
+        }.toSet()
+        _foldedLines.value = newFoldedLines
+        _content.update { _lines }
+    }
+
     fun removeLine(lineIdx: Int) {
-        updateContent(_internalStringBuilder.removeLineAt(lineIdx))
+        if (lineIdx in _lines.indices) {
+            val mutableLines = _lines.toMutableList()
+            mutableLines.removeAt(lineIdx)
+            updateLinesAndFolds(mutableLines.toList())
+        }
     }
 
     fun updateLine(lineIdx: Int, text: String) {
-        updateContent(_internalStringBuilder.updateLine(lineIdx, text))
+        if (lineIdx in _lines.indices) {
+            val mutableLines = _lines.toMutableList()
+            mutableLines[lineIdx] = text
+            updateLinesAndFolds(mutableLines.toList())
+        }
     }
 
     fun insertLine(lineIdx: Int, text: String) {
-        updateContent(_internalStringBuilder.insertLineAt(lineIdx, text))
+        val mutableLines = _lines.toMutableList()
+        mutableLines.add(if (lineIdx in 0.._lines.size) lineIdx else _lines.size, text)
+        updateLinesAndFolds(mutableLines.toList())
     }
 
-    fun getLine(lineIdx: Int): String {
-        return _internalStringBuilder.getLine(lineIdx)
+    fun getLine(lineIdx: Int): String = _lines[lineIdx]
+
+    fun toggleFold(startLineToToggle: Int) {
+        val currentFolded = _foldedLines.value.toMutableSet()
+        val rangeExists = _foldableRanges.value.any { it.startLine == startLineToToggle }
+
+        if (!rangeExists) {
+            if (currentFolded.contains(startLineToToggle)) {
+                currentFolded.remove(startLineToToggle)
+                _foldedLines.value = currentFolded
+            }
+            return
+        }
+
+        if (currentFolded.contains(startLineToToggle)) {
+            currentFolded.remove(startLineToToggle)
+        } else {
+            currentFolded.add(startLineToToggle)
+        }
+        _foldedLines.value = currentFolded
     }
 }

--- a/editor/src/main/java/com/itsvks/code/core/FoldableRanges.kt
+++ b/editor/src/main/java/com/itsvks/code/core/FoldableRanges.kt
@@ -1,0 +1,34 @@
+package com.itsvks.code.core
+
+data class FoldableRange(
+    val startLine: Int,
+    val endLine: Int,
+    // val startColumn: Int, // Let's omit column for now for simplicity
+    val type: String = "braces" // For future expansion (e.g., "imports", "comments")
+)
+
+fun findBraceFoldableRanges(lines: List<String>): List<FoldableRange> {
+    val ranges = mutableListOf<FoldableRange>()
+    val openBraceStack = ArrayDeque<Pair<Int, Int>>() // Pair of (lineIndex, charIndexInLine)
+
+    lines.forEachIndexed { lineIndex, line ->
+        line.forEachIndexed { charIndex, char ->
+            if (char == '{') {
+                openBraceStack.addLast(Pair(lineIndex, charIndex))
+            } else if (char == '}') {
+                if (openBraceStack.isNotEmpty()) {
+                    val (startLine, _) = openBraceStack.removeLast()
+                    // Add if the range spans multiple lines and is not empty
+                    if (startLine < lineIndex && lineIndex > startLine + 1) {
+                        // Ensure at least one line is hidden (startLine, startLine+1 ... lineIndex)
+                        // Foldable if it hides startLine+1 to lineIndex-1
+                        ranges.add(FoldableRange(startLine = startLine, endLine = lineIndex))
+                    }
+                }
+            }
+        }
+    }
+    // Sort ranges by start line, then by end line descending for nested blocks
+    // This helps in processing them later if needed.
+    return ranges.sortedWith(compareBy({ it.startLine }, { -it.endLine }))
+}


### PR DESCRIPTION
This commit introduces several enhancements to the code editor:

1.  **Code Loading and Scrolling Performance:**
    *   Refactored `CodeEditorState` to use `List<String>` instead of a single `StringBuilder` for content representation. This makes line access (getLine, lineCount) O(1), significantly improving rendering performance in `LazyColumn` for large files.
    *   Optimized `LanguageBasedSyntaxHighlighter` by pre-compiling and combining regexes for keywords, types, operators, and punctuation, reducing redundant regex operations during highlighting.
    *   Refactored the `highlightToken` function in `EditorTheme.kt` to use range-based styling (`addStyle`) instead of character-by-character styling, making the application of syntax styles more efficient.

2.  **Code Folding Feature (Brace-based):**
    *   Added logic to identify foldable regions based on matching curly braces (`{...}`) that span multiple lines (`core/FoldableRanges.kt`).
    *   Updated `CodeEditorState` to manage:
        *   The list of all potential foldable ranges.
        *   The set of currently folded regions.
        *   A method to toggle the fold state of a region.
        *   Automatic recalculation of foldable ranges and reconciliation of folded states upon code content changes.
    *   Modified the `CodeEditor` composable UI:
        *   Displays clickable markers ([+] / [-]) in the gutter next to foldable regions.
        *   Allows you to expand or collapse these regions by clicking the markers.
        *   When a region is collapsed, its content lines are hidden and replaced by a placeholder showing the first line and the count of hidden lines.
        *   The `LazyColumn` was refactored to render a derived list of "display lines," which includes code lines and folded markers.