### PR TITLE
I've resolved a compilation error in CodeEditor.kt.

### DIFF
--- a/editor/src/main/java/com/itsvks/code/component/CodeEditor.kt
+++ b/editor/src/main/java/com/itsvks/code/component/CodeEditor.kt
@@ -265,17 +265,20 @@ fun CodeEditor(
                                                 var updated = handleAutoIndent(it, textFieldValue)
                                                 updated = handleBracketPairMatch(updated, textFieldValue)
 
-                                                val newText = updated.text // This is AnnotatedString
+                                                val newText = updated.text // This is String, from TextFieldValue.text
                                                 // state.updateLine needs a String
-                                                state.updateLine(lineIdx, newText.text)
+                                                state.updateLine(lineIdx, newText)
 
-
-                                                textFieldValue = TextFieldValue(
-                                                    newText.highlight( // Re-highlight after potential structural changes by auto-indent
+                                                // textFieldValue needs an AnnotatedString.
+                                                // newText (String) needs to be highlighted to become AnnotatedString.
+                                                val highlightedAnnotatedString = newText.highlight( // Re-highlight after potential structural changes by auto-indent
                                                         theme = theme,
                                                         syntaxHighlighter = syntaxHighlighter,
                                                         bracketIndices = findBracketIndices(updated)
-                                                    ),
+                                                    )
+
+                                                textFieldValue = TextFieldValue(
+                                                    annotatedString = highlightedAnnotatedString,
                                                     selection = updated.selection,
                                                     composition = updated.composition
                                                 )


### PR DESCRIPTION
The issue was an "Unresolved reference: text" error within the onValueChange lambda of the BasicTextField in CodeEditor.kt.

This happened because `newText.text` was being called when `newText` was already a String. I've corrected this to simply use `newText`.

I also clarified the surrounding code to ensure that the TextFieldValue is updated with an AnnotatedString after syntax highlighting, while the CodeEditorState receives the plain String for its updates.